### PR TITLE
Split UploaderMessage into separate Observation and Payload messages

### DIFF
--- a/crates/observation-tools-client/src/lib.rs
+++ b/crates/observation-tools-client/src/lib.rs
@@ -33,8 +33,8 @@ pub use observation_handle::SendObservation;
 // Re-export procedural macro
 pub use observation_tools_macros::observe;
 // Re-export from shared for convenience
-use observation_tools_shared::Observation;
 pub use observation_tools_shared::Payload;
+pub use observation_tools_shared::PayloadBuilder;
 
 /// Register a global execution shared across all threads
 ///
@@ -63,10 +63,4 @@ pub fn current_execution() -> Option<ExecutionHandle> {
 /// This clears the execution context that is shared across all threads.
 pub fn clear_global_execution() {
   context::clear_global_execution()
-}
-
-#[derive(Debug)]
-struct ObservationWithPayload {
-  observation: Observation,
-  payload: Payload,
 }

--- a/crates/observation-tools-client/src/logger.rs
+++ b/crates/observation-tools-client/src/logger.rs
@@ -40,7 +40,7 @@ impl Log for ObservationLogger {
     let builder = ObservationBuilder::new("ObservationLogger")
       .observation_type(ObservationType::LogEntry)
       .log_level(record.level().into())
-      .label(format!("log/{}", record.target()));
+      .metadata("target", record.target());
     let builder = if let (Some(file), Some(line)) = (record.file(), record.line()) {
       builder.source(file, line)
     } else {

--- a/crates/observation-tools-client/src/server_client.rs
+++ b/crates/observation-tools-client/src/server_client.rs
@@ -1,6 +1,7 @@
 use crate::server_client::types::PayloadOrPointerResponse;
-use crate::ObservationWithPayload;
+use observation_tools_shared::Observation;
 use reqwest::multipart::Part;
+use serde::Serialize;
 use std::time::Duration;
 
 include!(concat!(env!("OUT_DIR"), "/observation_tools_openapi.rs"));
@@ -18,6 +19,13 @@ impl PayloadOrPointerResponse {
       PayloadOrPointerResponse::Json(j) => Some(j),
       _ => None,
     }
+  }
+}
+
+impl types::GetObservation {
+  /// Get the first (default) payload's data, for backward-compatible tests
+  pub fn payload(&self) -> &PayloadOrPointerResponse {
+    &self.payloads[0].data
   }
 }
 
@@ -51,41 +59,68 @@ pub async fn pre_hook_async(
   Ok(())
 }
 
+/// Default payload name used for the primary observation payload
+pub const DEFAULT_PAYLOAD_NAME: &str = "default";
+
+/// Entry in the payload manifest sent alongside the multipart form
+#[derive(Serialize)]
+struct PayloadManifestEntry {
+  observation_id: String,
+  payload_id: String,
+  name: String,
+  mime_type: String,
+  size: usize,
+}
+
 // Extension methods for Client
 impl Client {
   pub(crate) async fn create_observations_multipart(
     &self,
     execution_id: &str,
-    observations: Vec<ObservationWithPayload>,
+    observations: Vec<Observation>,
+    payloads: Vec<crate::client::PayloadUploadData>,
   ) -> anyhow::Result<()> {
+    if observations.is_empty() && payloads.is_empty() {
+      return Ok(());
+    }
+
     let url = format!("{}/api/exe/{}/obs", self.baseurl, execution_id);
-    let observation_count = observations.len();
 
     log::trace!(
-      "Creating observations via multipart: url={}, count={}",
+      "Creating observations via multipart: url={}, observations={}, payloads={}",
       url,
-      observation_count
+      observations.len(),
+      payloads.len()
     );
 
     // Build multipart form
     let mut form = reqwest::multipart::Form::new();
 
-    let (observations, payloads): (Vec<_>, Vec<_>) = observations
-      .into_iter()
-      .map(|obs| (obs.observation, obs.payload))
-      .unzip();
-    let payloads = observations
-      .iter()
-      .zip(payloads.into_iter())
-      .map(|(obs, payload)| (obs.id.to_string(), payload.data))
-      .collect::<Vec<_>>();
-
+    // Part 1: observations JSON
     let observations_json = serde_json::to_vec(&observations)?;
     let observations_part = Part::bytes(observations_json).mime_str("application/json")?;
     form = form.part("observations", observations_part);
-    for (obs_id, payload_data) in payloads {
-      let part = Part::bytes(payload_data);
-      form = form.part(obs_id, part);
+
+    // Part 2: payload manifest JSON
+    let manifest: Vec<PayloadManifestEntry> = payloads
+      .iter()
+      .map(|p| PayloadManifestEntry {
+        observation_id: p.observation_id.to_string(),
+        payload_id: p.payload_id.as_str().to_string(),
+        name: p.name.clone(),
+        mime_type: p.mime_type.clone(),
+        size: p.size,
+      })
+      .collect();
+    let manifest_json = serde_json::to_vec(&manifest)?;
+    let manifest_part = Part::bytes(manifest_json).mime_str("application/json")?;
+    form = form.part("payload_manifest", manifest_part);
+
+    // Part 3: payload data parts
+    for p in payloads {
+      let part_key = format!("{}:{}:{}", p.observation_id, p.payload_id.as_str(), p.name);
+      let part = Part::bytes(p.data);
+      form = form.part(part_key, part);
     }
 
     let mut request_builder = self.client.post(&url).multipart(form);


### PR DESCRIPTION
## Summary
- Split `UploaderMessage::Observations` into `::Observation` and `::Payload`
- Add `PayloadUploadData` for payload transport
- Add `send_with_execution_and_name` with default name "default"
- Update `server_client.rs` multipart upload for separate payloads
- Remove `ObservationWithPayload` type
- Rename labels to metadata in logger

**Stack:** PR 4/6 — client transport refactor (builds on #59)

## Test plan
- [ ] `cargo check -p observation-tools` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)