### PR TITLE
Update axum, tracing integrations and tests for groups and named payloads

### DIFF
--- a/crates/observation-tools-client/tests/common/mod.rs
+++ b/crates/observation-tools-client/tests/common/mod.rs
@@ -112,7 +112,7 @@ impl TestServer {
     observation_tools::server_client::create_client(&self.base_url, Some(api_key.to_string()))
   }
 
-  /// List all observations for an execution
+  /// List all observations for an execution (payloads returned as Pointers)
   #[allow(unused)]
   pub async fn list_observations(
     &self,
@@ -125,6 +125,23 @@ impl TestServer {
       .send()
       .await?;
     Ok(response.observations.clone())
+  }
+
+  /// Get a single observation with inline payload data
+  #[allow(unused)]
+  pub async fn get_observation(
+    &self,
+    execution_id: &impl ToString,
+    observation_id: &impl ToString,
+  ) -> anyhow::Result<GetObservation> {
+    let api_client = self.create_api_client()?;
+    let response = api_client
+      .get_observation()
+      .execution_id(&execution_id.to_string())
+      .observation_id(&observation_id.to_string())
+      .send()
+      .await?;
+    Ok(response.observation.clone())
   }
 
   #[allow(unused)]

--- a/crates/observation-tools-client/tests/logger_test.rs
+++ b/crates/observation-tools-client/tests/logger_test.rs
@@ -21,8 +21,8 @@ async fn test_logger() -> anyhow::Result<()> {
   let observations = server.list_observations(&execution.id()).await?;
 
   assert_eq!(observations.len(), 2);
-  let obs = &observations[0];
-  assert_eq!(obs.payload.as_str(), Some("info-log"));
+  let obs = server.get_observation(&execution.id(), &observations[0].id).await?;
+  assert_eq!(obs.payload().as_str(), Some("info-log"));
   assert_eq!(obs.observation_type, ObservationType::LogEntry);
   assert_eq!(obs.log_level, LogLevel::Info);
 

--- a/tests/helpers/testIds.ts
+++ b/tests/helpers/testIds.ts
@@ -23,7 +23,7 @@ export enum TestId {
   ObservationListItemLink = "ObservationListItemLink",
   ObservationId = "ObservationId",
   ObservationPayload = "ObservationPayload",
-  ObservationLabels = "ObservationLabels",
+  ObservationGroups = "ObservationGroups",
   ObservationSourceFile = "ObservationSourceFile",
   ObservationSourceLine = "ObservationSourceLine",
   ObservationMetadataHeader = "ObservationMetadataHeader",

--- a/tests/specs/tests.spec.ts
+++ b/tests/specs/tests.spec.ts
@@ -35,7 +35,7 @@ test("Create execution with observation and verify data", async ({ page, server 
   const exe = client.beginExecution(executionName);
   const observationName = "test-observation";
   const observationPayload = { message: "Hello, World!", count: 42, nested: { value: true } };
-  const observationLabels = ["api", "test"];
+  const observationGroups = ["api", "test"];
   const sourceFile = "test.ts";
   const sourceLine = 123;
   const observationMetadata = [
@@ -44,8 +44,8 @@ test("Create execution with observation and verify data", async ({ page, server 
     ["user", "test-user"],
   ];
   let builder = new ObservationBuilder(observationName);
-  for (const label of observationLabels) {
-    builder = builder.label(label);
+  for (const label of observationGroups) {
+    builder = builder.group(label);
   }
   for (const [key, value] of observationMetadata) {
     builder = builder.metadata(key, value);
@@ -70,8 +70,8 @@ test("Create execution with observation and verify data", async ({ page, server 
   await expect(page.getByTestId(TestId.ObservationPayload)).toBeVisible();
   await expect(page.getByTestId(TestId.ObservationPayload)).toContainText("Hello, World!");
   await expect(page.getByTestId(TestId.ObservationPayload)).toContainText("42");
-  for (const label of observationLabels) {
-    await expect(page.getByTestId(TestId.ObservationLabels)).toContainText(label);
+  for (const label of observationGroups) {
+    await expect(page.getByTestId(TestId.ObservationGroups)).toContainText(label);
   }
   await expect(page.getByTestId(TestId.ObservationSourceFile)).toContainText(sourceFile);
   await expect(page.getByTestId(TestId.ObservationSourceLine)).toContainText(sourceLine.toString());
@@ -193,8 +193,8 @@ test("Large payload is uploaded as blob", async ({ page, server }) => {
   const largeData = "x".repeat(70000);
   const largePayload = { data: largeData, size: largeData.length };
   const observationId = new ObservationBuilder(observationName)
-    .label("test")
-    .label("large-payload")
+    .group("test")
+    .group("large-payload")
     .jsonPayload(JSON.stringify(largePayload))
     .send(exe)
     .handle().id;
@@ -347,7 +347,7 @@ test.describe("Auto-refresh behavior", () => {
       const observation1Name = "first-observation";
       const observation1Payload = { message: "First observation data" };
       const observation1Id = new ObservationBuilder(observation1Name)
-        .label("test")
+        .group("test")
         .source("test.ts", 10)
         .jsonPayload(JSON.stringify(observation1Payload))
         .send(exe)
@@ -356,7 +356,7 @@ test.describe("Auto-refresh behavior", () => {
       const observation2Name = "second-observation";
       const observation2Payload = { message: "Second observation data" };
       const observation2Id = new ObservationBuilder(observation2Name)
-        .label("test")
+        .group("test")
         .source("test.ts", 20)
         .jsonPayload(JSON.stringify(observation2Payload))
         .send(exe)


### PR DESCRIPTION
## Summary
- Axum HTTP observer uses groups for request/response hierarchy
- Tracing layer uses groups for span-based observation grouping
- All tests updated for multi-payload and group APIs

**Stack:** PR 6/6 — integrations + tests (builds on #61)

This is the final PR in the stack. `groups-6-integrations` exactly matches the `groups` branch. `cargo test` passes.

## Test plan
- [ ] `cargo test` passes
- [ ] `git diff groups groups-6-integrations` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)