### PR TITLE
Unify payload method naming

### DIFF
--- a/crates/observation-tools-client/src/axum/request_observer.rs
+++ b/crates/observation-tools-client/src/axum/request_observer.rs
@@ -65,7 +65,7 @@ impl Drop for StreamingObserverState {
       size: bytes.len(),
     };
 
-    self.payload_handle.raw_payload("body", payload);
+    self.payload_handle.payload("body", payload);
   }
 }
 
@@ -251,8 +251,8 @@ where
         .metadata("method", parts.method.to_string())
         .metadata("uri", parts.uri.to_string())
         .execution(&execution)
-        .named_raw_payload("headers", headers_payload)
-        .raw_payload("body", bytes_to_payload(&request_body_bytes, &parts.headers));
+        .named_payload("headers", headers_payload)
+        .payload("body", bytes_to_payload(&request_body_bytes, &parts.headers));
 
       let response = inner
         .call(Request::from_parts(parts, Body::from(request_body_bytes)))
@@ -277,7 +277,7 @@ where
         .metadata("status", &parts.status.as_u16().to_string())
         .log_level(log_level)
         .execution(&execution)
-        .named_raw_payload("headers", resp_headers_payload);
+        .named_payload("headers", resp_headers_payload);
 
       // Wrap the response body in a streaming observer that captures data as it flows
       // through and adds the body payload when the stream completes

--- a/crates/observation-tools-client/src/observation_handle.rs
+++ b/crates/observation-tools-client/src/observation_handle.rs
@@ -146,24 +146,24 @@ impl ObservationPayloadHandle {
   }
 
   /// Add a named payload serialized via serde
-  pub fn payload<T: ?Sized + serde::Serialize>(&self, name: impl Into<String>, value: &T) -> &Self {
+  pub fn serde<T: ?Sized + serde::Serialize>(&self, name: impl Into<String>, value: &T) -> &Self {
     let payload =
       observation_tools_shared::Payload::json(serde_json::to_string(value).unwrap_or_default());
-    self.raw_payload(name, payload)
+    self.payload(name, payload)
   }
 
   /// Add a named payload formatted via Debug
-  pub fn debug_payload<T: std::fmt::Debug + ?Sized>(
+  pub fn debug<T: std::fmt::Debug + ?Sized>(
     &self,
     name: impl Into<String>,
     value: &T,
   ) -> &Self {
     let payload = observation_tools_shared::Payload::debug(format!("{:#?}", value));
-    self.raw_payload(name, payload)
+    self.payload(name, payload)
   }
 
-  /// Add a named raw payload
-  pub fn raw_payload(&self, name: impl Into<String>, payload: observation_tools_shared::Payload) -> &Self {
+  /// Add a named payload
+  pub fn payload(&self, name: impl Into<String>, payload: impl Into<observation_tools_shared::Payload>) -> &Self {
     let _ = self
       .execution
       .uploader_tx
@@ -172,7 +172,7 @@ impl ObservationPayloadHandle {
         execution_id: self.handle.execution_id,
         payload_id: observation_tools_shared::PayloadId::new(),
         name: name.into(),
-        payload,
+        payload: payload.into(),
       });
     self
   }

--- a/crates/observation-tools-client/tests/api_integration_test.rs
+++ b/crates/observation-tools-client/tests/api_integration_test.rs
@@ -365,10 +365,10 @@ async fn test_named_payloads() -> anyhow::Result<()> {
     // Create an observation with a named payload, then add more payloads via the handle
     let handle = ObservationBuilder::new("multi-payload-obs")
       .metadata("kind", "multi")
-      .named_payload("headers", &json!({"content-type": "application/json"}));
+      .named_serde("headers", &json!({"content-type": "application/json"}));
 
-    handle.payload("body", &json!({"message": "hello"}));
-    handle.raw_payload(
+    handle.serde("body", &json!({"message": "hello"}));
+    handle.payload(
       "raw-part",
       Payload::text("some raw text"),
     );


### PR DESCRIPTION
## Summary
- Rename `named_payload` → `named_serde` and `named_raw_payload` → `named_payload` on `ObservationBuilder` so `payload` consistently means "accepts `Into<Payload>`"
- Rename `payload` → `serde`, `debug_payload` → `debug`, and `raw_payload` → `payload` on `ObservationPayloadHandle` for the same consistency
- Update all call sites in axum middleware and integration tests

## Test plan
- [x] `cargo build --workspace --all-features` passes
- [x] `cargo test --workspace --all-features` passes (all 70 tests)
- [x] Grep confirms no remaining references to old method names (`named_raw_payload`, `raw_payload`, `debug_payload`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)